### PR TITLE
refactor: reimplement with babylon

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    "es2015-node4",
-    "stage-0"
-  ],
-  "plugins": [
-    "add-module-exports"
-  ]
-}

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
-spin = false
-progress = false
 save-exact = true
-cache-min = 99999999

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+language: node_js
+node_js:
+- '6'
+- '5'
+- '4'
+branches:
+  only:
+    - master
+cache:
+  directories:
+  - node_modules
+notifications:
+  email:
+    on_success: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+environment:
+  matrix:
+    - nodejs_version: '6'
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+cache:
+  - node_modules
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - set PATH=%APPDATA%\npm;%PATH%
+  - node --version
+  - npm --version
+matrix:
+  fast_finish: true
+max_jobs: 6
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+build: off
+before_test:
+  - npm install
+test_script:
+  - npm test
+deploy: off
+branches:
+  only:
+    - master

--- a/package.json
+++ b/package.json
@@ -8,22 +8,41 @@
   ],
   "scripts": {
     "start": "npm run watch",
-    "clean": "rm -rf distribution",
-    "prepare": "mkdir -p distribution",
-    "prebuild": "parallelshell 'npm run test' 'npm run clean && npm run prepare'",
-    "build": "babel source --out-dir distribution && echo '' || notify -t $npm_package_name -m 'Build failed! 😢'",
-    "postbuild": "npm run notify",
-    "test": "(eslint source/**/*.js && conventional-changelog-lint --to=HEAD~1 && jsonlint-cli **/*.json) && echo '' || notify -t $npm_package_name -m 'Linting failed! 😢'",
-    "watch": "watch 'npm run build' source",
-    "notify": "echo 'Build ready, happy hacking! ✊' && notify -t $npm_package_name -m 'Build ready, happy hacking! ✊'",
-    "commit": "git-cz",
+    "watch": "npm run build -- --watch",
+    "clean": "rm -r distribution",
+    "build": "babel source --out-dir distribution",
+    "test": "npm run lint && npm run build && npm run deps && ava",
+    "lint": "xo source/**/*.js",
+    "deps": "dependency-check . --missing && dependency-check . --extra --no-dev",
     "commitmsg": "conventional-changelog-lint -e",
-    "changelog": "conventional-changelog --preset angular --infile changelog.md --same-file --output-unreleased",
-    "push": "git push && git push --tags && hub release create \"v$(cat .git/RELEASE_VERSION.tmp)\" --message=\"v$(cat .git/RELEASE_VERSION.tmp)\n$(cat .git/COMMITMSG.tmp)\" && npm publish && rm .git/RELEASE_VERSION.tmp && rm .git/COMMITMSG.tmp",
-    "release": "npm version $(conventional-recommended-bump -p angular)",
-    "preversion": "npm run build && npm test",
-    "version": "npm run changelog && git add . && echo \"$(conventional-changelog -p angular)\" > .git/COMMITMSG.tmp",
-    "postversion": "echo $(git log -1 --pretty=%B HEAD^..HEAD) > .git/RELEASE_VERSION.tmp && git tag -d v$(cat .git/RELEASE_VERSION.tmp) && git commit --amend -m \"chore(release): $(cat .git/RELEASE_VERSION.tmp)\n$(cat .git/COMMITMSG.tmp)\" && git tag -a v$(cat .git/RELEASE_VERSION.tmp) -m \"$(cat .git/COMMITMSG.tmp)\""
+    "changelog": "conventional-changelog -p angular -i changelog.md -s -u",
+    "prerelease": "npm run clean && npm run build",
+    "release": "npm version --no-git-tag-version $(conventional-recommended-bump -p angular)",
+    "release:stage": "git add changelog.md package.json",
+    "release:commit": "git commit --amend -m \"chore(release): v$npm_package_version\n$(conventional-changelog -p angular)\"",
+    "release:tag": "git tag -a v$npm_package_version -m \"$(conventional-changelog -p angular)\"",
+    "version": "npm run changelog && npm run release:stage",
+    "postversion": "npm run release:commit && npm run release:tag",
+    "push": "npm run push:git && npm run push:github",
+    "push:git": "git push && git push --tags",
+    "push:github": "hub release create \"v$npm_package_version\" --message=\"v$npm_package_version\n$(conventional-changelog -p angular)\"",
+    "push:npm": "npm publish"
+  },
+  "babel": {
+    "presets": [
+      "es2015-node4",
+      "stage-0"
+    ],
+    "plugins": [
+      "add-module-exports"
+    ]
+  },
+  "ava": {
+    "babel": "inherit",
+    "require": [
+      "babel-register",
+      "babel-polyfill"
+    ]
   },
   "repository": {
     "type": "git",
@@ -58,29 +77,30 @@
     "MIT"
   ],
   "devDependencies": {
-    "babel": "6.5.2",
-    "babel-cli": "6.4.0",
-    "babel-eslint": "4.1.8",
-    "babel-plugin-add-module-exports": "0.1.2",
-    "babel-preset-es2015-node4": "2.0.3",
-    "babel-preset-stage-0": "6.3.13",
-    "commitizen": "2.5.0",
-    "conventional-changelog-cli": "1.1.1",
-    "conventional-changelog-lint": "0.1.7",
-    "conventional-recommended-bump": "0.1.0",
-    "cz-conventional-changelog": "1.1.5",
-    "eslint": "1.10.3",
-    "eslint-config-xo": "0.9.1",
-    "eslint-plugin-babel": "3.1.0",
-    "husky": "0.10.2",
-    "jsonlint-cli": "0.2.7",
-    "node-notifier": "4.4.0",
-    "parallelshell": "2.0.0",
-    "react": ">= 0.13",
-    "react-dom": ">= 0.13",
-    "watch": "0.17.1"
+    "ava": "0.16.0",
+    "babel-cli": "6.14.0",
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-polyfill": "6.13.0",
+    "babel-preset-es2015-node4": "2.1.0",
+    "babel-preset-stage-0": "6.5.0",
+    "babel-register": "6.14.0",
+    "conventional-changelog-cli": "1.2.0",
+    "conventional-changelog-lint": "1.0.1",
+    "conventional-recommended-bump": "0.3.0",
+    "cz-conventional-changelog": "1.2.0",
+    "cz-conventional-changelog-lint": "0.1.3",
+    "dependency-check": "2.6.0",
+    "husky": "0.11.7",
+    "lodash": "4.16.0",
+    "xo": "0.16.0"
   },
   "dependencies": {
-    "patternplate-transforms-core": "^0.1.1"
+    "babel-code-frame": "6.11.0",
+    "babel-generator": "6.14.0",
+    "babel-traverse": "6.15.0",
+    "babel-types": "6.15.0",
+    "babylon": "6.9.2",
+    "patternplate-transforms-core": "0.1.2",
+    "resolve": "1.1.7"
   }
 }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -1,0 +1,23 @@
+/* eslint-disable xo/filename-case */
+import {merge} from 'lodash';
+
+export function getFile(extender) {
+	const file = {
+		format: 'js',
+		path: 'mocks/index.js',
+		pattern: {
+			id: 'mocks'
+		},
+		dependencies: {},
+		meta: {
+			dependencies: []
+		}
+	};
+	return merge({}, file, extender);
+}
+
+export function selectConfig(app) {
+	const config = app.configuration || {};
+	const transforms = config.transforms || {};
+	return transforms['resolve-imports'];
+}

--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -1,0 +1,118 @@
+/* eslint-disable xo/filename-case */
+import {getFile} from './_helpers';
+
+export const application = {
+	cache: {
+		get() {
+			return false;
+		},
+		set() {
+		}
+	},
+	configuration: {}
+};
+
+export const misconfigured = {
+	cache: {
+		get() {
+			return false;
+		},
+		set() {
+		}
+	},
+	configuration: {
+		transforms: {
+			'resolve-imports': {
+				foo: 'js'
+			}
+		}
+	}
+};
+
+export const missingFormat = {
+	cache: {
+		get() {
+			return false;
+		},
+		set() {
+		}
+	},
+	configuration: {
+		transforms: {
+			'resolve-imports': {
+				outFormat: 'js'
+			}
+		}
+	}
+};
+
+export const configured = {
+	cache: {
+		get() {
+			return false;
+		},
+		set() {
+		}
+	},
+	configuration: {
+		patterns: {
+			formats: {
+				js: {
+					name: 'js'
+				}
+			}
+		},
+		transforms: {
+			'resolve-imports': {
+				outFormat: 'js'
+			}
+		}
+	}
+};
+
+export const emptyFile = getFile({
+	buffer: '',
+	path: 'empty/index.js',
+	pattern: {
+		id: 'empty'
+	},
+	dependencies: {}
+});
+
+export const dependingFile = getFile({
+	buffer: 'const empty = require("empty")',
+	path: 'depending-file/index.js',
+	pattern: {
+		id: 'depending-file'
+	},
+	dependencies: {
+		empty: emptyFile
+	}
+});
+
+export const missingFile = getFile({
+	buffer: 'const empty = require("missing")',
+	path: 'depending-file/index.js',
+	pattern: {
+		id: 'depending-file'
+	},
+	dependencies: {
+		empty: emptyFile
+	}
+});
+
+export const externalFile = getFile({
+	buffer: 'const _ = require("lodash")',
+	path: 'external-file/index.js',
+	pattern: {
+		id: 'external-file'
+	}
+});
+
+export const externalSubFile = getFile({
+	buffer: 'const fp = require("lodash/fp")',
+	path: 'external-file/index.js',
+	pattern: {
+		id: 'external-file'
+	}
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,74 @@
+import test from 'ava';
+import factory from '../source';
+import {selectConfig} from './_helpers';
+import * as mocks from './_mocks';
+
+test('it should export a function as default', t => {
+	const actual = typeof factory;
+	const expected = 'function';
+	t.deepEqual(actual, expected);
+});
+
+test('calling the function should return a function', t => {
+	const actual = typeof factory(mocks.application);
+	const expected = 'function';
+	t.deepEqual(actual, expected);
+});
+
+test('calling the returned function should return a promise', t => {
+	const transform = factory(mocks.configured);
+	const actual = transform(mocks.emptyFile, null, selectConfig(mocks.configured)).constructor.name;
+	const expected = 'Promise';
+	t.deepEqual(actual, expected);
+});
+
+test('the returned promise should reject when not configured', async t => {
+	const transform = factory(mocks.application);
+	t.throws(transform(mocks.emptyFile, null, selectConfig(mocks.application)), /not configured in/);
+});
+
+test('the returned promise should reject when no outformat is configured', async t => {
+	const transform = factory(mocks.misconfigured);
+	t.throws(transform(mocks.emptyFile, null, selectConfig(mocks.misconfigured)), /no configured .outFormat/);
+});
+
+test('the returned promise should reject when no matching format is configured', async t => {
+	const transform = factory(mocks.missingFormat);
+	t.throws(transform(mocks.emptyFile, null, selectConfig(mocks.missingFormat)), /is not configured. Available formats:/);
+});
+
+test('the returned promise should reject when no file is given', async t => {
+	const transform = factory(mocks.missingFormat);
+	t.throws(transform(null, null, selectConfig(mocks.missingFormat)), /invalid file/);
+});
+
+test('a simple pattern dependency should be resolved correctly', async t => {
+	const transform = factory(mocks.configured);
+	const file = await transform(mocks.dependingFile, null, selectConfig(mocks.configured));
+	t.is(file.buffer, 'const empty = require("../empty");');
+});
+
+test('a missing pattern dependency should throw', async t => {
+	const transform = factory(mocks.configured);
+	t.throws(transform(mocks.missingFile, null, selectConfig(mocks.missingFormat)), /Cannot find module 'missing'/);
+});
+
+test('an external dependency should be regeistered', async t => {
+	const transform = factory(mocks.configured);
+	const result = await transform(mocks.externalFile, null, selectConfig(mocks.configured));
+	t.deepEqual(result.meta.dependencies, ['lodash']);
+});
+
+test('an external dependency should be regeistered exactly once', async t => {
+	const transform = factory(mocks.configured);
+	const result = await transform(mocks.externalFile, null, selectConfig(mocks.configured));
+	await transform(mocks.externalFile, null, selectConfig(mocks.configured));
+	t.deepEqual(result.meta.dependencies, ['lodash']);
+});
+
+test('an external dependency with subpaths should be registered with package name', async t => {
+	const transform = factory(mocks.configured);
+	const result = await transform(mocks.externalSubFile, null, selectConfig(mocks.configured));
+	await transform(mocks.externalSubFile, null, selectConfig(mocks.configured));
+	t.deepEqual(result.meta.dependencies, ['lodash']);
+});


### PR DESCRIPTION
-  traverse ast to find imports, require calls
-  add basic test suite
-  update all dependencies
-  add ci setup

BREAKING CHANGE: asserts validity of configuration and file inputs
